### PR TITLE
Use pytest instead of py.test per upstream recommendation, #dropthedot

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Developing
 
   .. code-block:: console
 
-      $ py.test --doctest-glob='*.rst' --doctest-mod
+      $ pytest --doctest-glob='*.rst' --doctest-mod
 
 Testing
 -------

--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,8 @@ commands =
     check-manifest --ignore tox.ini,tests*
     python setup.py check -m -s
     flake8 .
-    py.test tests
-    py.test --doctest-glob='*.rst' --doctest-modules
+    pytest tests
+    pytest --doctest-glob='*.rst' --doctest-modules
 [flake8]
 exclude = .tox,*.egg,build,data
 select = E,W,F


### PR DESCRIPTION
http://blog.pytest.org/2016/whats-new-in-pytest-30/
https://twitter.com/hashtag/dropthedot